### PR TITLE
Add permission to allow for discord RPC

### DIFF
--- a/com.modrinth.ModrinthApp.yml
+++ b/com.modrinth.ModrinthApp.yml
@@ -7,7 +7,8 @@ sdk: org.gnome.Sdk
 command: modrinth-app
 finish-args:
   - --filesystem=xdg-download:ro # allow drag and drop from downloads
-  - --filesystem=xdg-run/app/com.discordapp.Discord:create # allows for discord rpc
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create # allows for discord rpc (flatpak)
+  - --filesystem=xdg-run/discord-ipc-0 # allows for discord rpc
   # We can't use this yet, see <https://github.com/flatpak/flatpak/issues/5681>
   # So we have to use device=all
   # - --device=dri


### PR DESCRIPTION
alr existing permission only allowed rpc for the flatpak discord

tested on Arch linux